### PR TITLE
Create user groups and assign permissions on post_syncdb signal

### DIFF
--- a/systers_portal/dashboard/management/__init__.py
+++ b/systers_portal/dashboard/management/__init__.py
@@ -1,0 +1,63 @@
+from django.db.models.signals import post_syncdb
+from django.contrib.auth.models import Group, Permission
+from dashboard import models
+
+
+content_contributor_permissions = [
+    "add_resource",
+    "change_resource",
+    "change_communitypage",
+    "add_news",
+    "change_news",
+    "add_tag",
+    "change_tag",
+    "add_resourcetype",
+    "change_resourcetype",
+]
+
+content_manager_permissions = content_contributor_permissions + [
+    "delete_resource",
+    "add_communitypage",
+    "delete_communitypage",
+    "delete_news",
+    "delete_tag",
+    "delete_resourcetype",
+]
+
+user_content_manager_permissions = content_manager_permissions + [
+    "add_systeruser",
+    "change_systeruser",
+    "delete_systeruser",
+]
+
+community_admin_permissions = user_content_manager_permissions + [
+    "change_community",
+]
+
+dashboard_group_permissions = {
+    "Content Contributor": content_contributor_permissions,
+    "Content Manager": content_manager_permissions,
+    "User and Content Manager": user_content_manager_permissions,
+    "Community Admin": community_admin_permissions
+}
+
+
+def create_user_groups(sender, **kwargs):
+    """Create user groups and assign permissions to each group
+
+    :param sender: models module that was just installed
+    """
+    verbosity = kwargs.get("verbosity")
+    if verbosity > 0:
+        print "Initializing data post_syncdb"
+    for group in dashboard_group_permissions:
+        role, created = Group.objects.get_or_create(name=group)
+        if verbosity > 1 and created:
+            print "Creating group {0}".format(group)
+        for perm in dashboard_group_permissions[group]:
+            role.permissions.add(Permission.objects.get(codename=perm))
+            if verbosity > 1:
+                print "Permitting {0} to {1}".format(group, perm)
+        role.save()
+
+post_syncdb.connect(create_user_groups, sender=models)

--- a/systers_portal/dashboard/tests.py
+++ b/systers_portal/dashboard/tests.py
@@ -1,10 +1,15 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.contrib.auth.models import Group
 from cms.models.pagemodel import Page
 from cms.api import create_page
-from dashboard.models import (
-    SysterUser, Community, News, Resource, Tag, ResourceType,
-    CommunityPage)
+
+from dashboard.management import (content_contributor_permissions,
+                                  content_manager_permissions,
+                                  user_content_manager_permissions,
+                                  community_admin_permissions)
+from dashboard.models import (SysterUser, Community, News, Resource, Tag,
+                              ResourceType, CommunityPage)
 
 
 class DashboardTestCase(TestCase):
@@ -188,3 +193,18 @@ class DashboardTestCase(TestCase):
             communitypage=about_page_for_second_dummy_community)
         self.assertEqual(about_second_dummy_community,
                          second_dummy_community_about)
+
+    def test_group_permissions(self):
+        groups = ["Content Contributor",
+                  "Content Manager",
+                  "User and Content Manager",
+                  "Community Admin", ]
+        permissions = [content_contributor_permissions,
+                       content_manager_permissions,
+                       user_content_manager_permissions,
+                       community_admin_permissions, ]
+        for i, group_name in enumerate(groups):
+            group = Group.objects.get(name=group_name)
+            group_permissions = [p.codename for p in
+                                 list(group.permissions.all())]
+            self.assertItemsEqual(group_permissions, permissions[i])

--- a/systers_portal/systers_portal/settings/testing.py
+++ b/systers_portal/systers_portal/settings/testing.py
@@ -14,3 +14,5 @@ DATABASES = {
     }
 }
 INTERNAL_IPS = ('127.0.0.1',)
+
+ROOT_URLCONF = 'systers_portal.systers_portal.urls'


### PR DESCRIPTION
The following change is dependent on #9 and makes assumptions about model class names, since default permissions are created using those. 

This PR will be changed accordingly and rebased against merged models. The manual testing was done using dummy models, but doesn't include those, nor the app `__init__.py`or updates in `base.py` settings.

The user groups define 4 different levels of access. The admin level is not included, since this is the Systers Keeper and by becoming Django superuser she has access to everything via admin panel.

I have written a test for the following change, but it fails, because the order of running syncdb handlers is different in test mode. By running `python manage.py syncdb` the order is the following:
- Running post-sync handlers for application dashboard
- Adding permission 'dashboard | model name | Can add/change/delete model name'
- Initializing data post_syncdb

When running `python manage.py test`:
- Running post-sync handlers for application dashboard
- Initializing data post_syncdb
- Exception raised because `create_user_groups` tries to get permission objects from the database, but those were not yet inserted

Is it possible to force a specific order on syncdb execution in test mode? Or maybe there is a better way to solve the issue?
