### PR TITLE
Update testing settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Setup for developers
 7. Run `python systers_portal/manage.py syncdb`
 8. Run `python systers_portal/manage.py runserver` to start the development server. When in testing
   or production, feed the respective settings file from the command line, e.g. for  
-  testing `python manage.py runserver settings=systers_portal.settings.testing`
+  testing `python manage.py runserver --settings=systers_portal.settings.testing`
 9. Before commiting run `flake8 systers_portal` and fix PEP8 warnings
-10. Run `python systers_portal/manage.py test` to run all the tests
+10. Run `python systers_portal/manage.py test --settings=systers_portal.settings.testing`
+  to run all the tests
 
 
 Documentation

--- a/systers_portal/systers_portal/settings/testing.py
+++ b/systers_portal/systers_portal/settings/testing.py
@@ -13,6 +13,14 @@ DATABASES = {
         'PORT': '5432',
     }
 }
+
 INTERNAL_IPS = ('127.0.0.1',)
 
 ROOT_URLCONF = 'systers_portal.systers_portal.urls'
+
+NOSE_ARGS = [
+    '--nocapture',
+    '--nologcapture',
+    '--with-doctest',
+    '--doctest-options=+ELLIPSIS',
+]

--- a/systers_portal/systers_portal/urls.py
+++ b/systers_portal/systers_portal/urls.py
@@ -1,7 +1,10 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
-admin.autodiscover()
+try:
+    admin.autodiscover()
+except admin.sites.AlreadyRegistered:
+    pass
 
 urlpatterns = patterns(
     '',


### PR DESCRIPTION
While testing I found those test arguments useful and decided to make them accessible for future developers.

`NOSE_ARGS` contains option flag to run doctests with options `ELLIPSIS`. This is relevant if others will want to run or write new doctests. The `--nocapture` is for not capturing stdout -- useful when debugging. 
