### PR TITLE
Changed Community page model to include placeholderfield 

### DIFF
--- a/systers_portal/dashboard/admin.py
+++ b/systers_portal/dashboard/admin.py
@@ -2,11 +2,16 @@ from django.contrib import admin
 from dashboard.models import (
     SysterUser, Community, News, Resource, Tag, ResourceType,
     CommunityPage)
+from cms.admin.placeholderadmin import PlaceholderAdminMixin
 
+
+class CommunityPageAdmin(PlaceholderAdminMixin, admin.ModelAdmin):
+    pass
+
+admin.site.register(CommunityPage, CommunityPageAdmin)
 admin.site.register(SysterUser)
 admin.site.register(Community)
 admin.site.register(News)
 admin.site.register(Resource)
 admin.site.register(Tag)
 admin.site.register(ResourceType)
-admin.site.register(CommunityPage)

--- a/systers_portal/dashboard/models.py
+++ b/systers_portal/dashboard/models.py
@@ -3,11 +3,11 @@ from django.contrib.auth.models import User
 from django.dispatch import receiver
 from django_countries.fields import CountryField
 from allauth.account.signals import user_signed_up
-from cms.models.pagemodel import Page
+from cms.models.fields import PlaceholderField
+from django.core.urlresolvers import reverse
 
 
 class SysterUser(models.Model):
-
     """Profile model to store additional information about a user"""
     user = models.OneToOneField(User)
     country = CountryField(blank=True, null=True)
@@ -28,7 +28,6 @@ class SysterUser(models.Model):
 
 
 class Community(models.Model):
-
     """Model to represent a Syster Community"""
     name = models.CharField(max_length=255)
     email = models.EmailField(max_length=255, blank=True)
@@ -49,7 +48,6 @@ class Community(models.Model):
 
 
 class Tag(models.Model):
-
     """Model to represent the tags a resource can have"""
     name = models.CharField(max_length=255)
 
@@ -58,7 +56,6 @@ class Tag(models.Model):
 
 
 class ResourceType(models.Model):
-
     """Model to represent the types a resource can have"""
     name = models.CharField(max_length=255)
 
@@ -67,7 +64,6 @@ class ResourceType(models.Model):
 
 
 class News(models.Model):
-
     """Model to represent a News section on Community resource area"""
     title = models.CharField(max_length=255)
     community = models.ForeignKey(Community)
@@ -84,18 +80,20 @@ class News(models.Model):
 
 
 class CommunityPage(models.Model):
-
     """Model to represent community pages"""
     title = models.CharField(max_length=255)
-    page = models.OneToOneField(Page)
+    editable_content = PlaceholderField('editable_content')
     community = models.ForeignKey(Community)
+    slug = models.SlugField(max_length=150, unique=True)
 
     def __unicode__(self):
-        return "{0} of {1} Community".format(self.page, self.community.name)
+        return "{0} of {1} Community".format(self.title, self.community.name)
+
+    def get_absolute_url(self):
+        return reverse('edit_page', args=[self.community.slug, self.slug])
 
 
 class Resource(models.Model):
-
     """Model to represent a Resources section on Community resource area"""
     title = models.CharField(max_length=255)
     community = models.ForeignKey(Community)

--- a/systers_portal/dashboard/tests.py
+++ b/systers_portal/dashboard/tests.py
@@ -4,8 +4,6 @@ from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from django.contrib.auth.models import Group
-from cms.models.pagemodel import Page
-from cms.api import create_page
 from allauth.account import signals
 
 from dashboard.decorators import (membership_required, admin_required,
@@ -148,57 +146,18 @@ class DashboardModelsTestCase(TestCase):
         systeruser = SysterUser.objects.create(user=self.auth_user)
         community = Community.objects.create(name='dummy_community',
                                              community_admin=systeruser)
-        about_dummy_community = create_page('About',
-                                            'page_template.html',
-                                            'en-us')
-        about_page_for_dummy_community = CommunityPage.objects.create(
+        about_dummy_community = CommunityPage.objects.create(
             title='About',
-            page=about_dummy_community,
-            community=community)
+            community=community,
+            slug='about')
         self.assertEqual(len(Community.objects.all()), 1)
-        self.assertEqual(len(Page.objects.all()), 1)
+        self.assertEqual(len(SysterUser.objects.all()), 1)
         self.assertEqual(len(CommunityPage.objects.all()), 1)
-        self.assertEqual(len(Page.objects.all()), 1)
-        self.assertEqual(unicode(about_page_for_dummy_community),
+        self.assertEqual(unicode(about_dummy_community),
                          'About of dummy_community Community')
-        self.assertEqual(about_page_for_dummy_community.page,
-                         about_dummy_community)
-        self.assertEqual(about_page_for_dummy_community.community, community)
-        faq_dummy_community = create_page('faq', 'page_template.html', 'en-us')
-        self.assertEqual(len(Page.objects.all()), 2)
-        faq_page_for_dummy_community = CommunityPage.objects.create(
-            title='FAQ',
-            page=faq_dummy_community,
-            community=community)
-        self.assertEqual(faq_page_for_dummy_community.page,
-                         faq_dummy_community)
-        self.assertEqual(faq_page_for_dummy_community.community, community)
-        second_community = Community.objects.create(
-            name='second_dummy_community',
-            community_admin=systeruser,
-            slug='second_community',)
-        about_second_dummy_community = create_page('About',
-                                                   'page_template.html',
-                                                   'en-us')
-        about_page_for_second_dummy_community = CommunityPage.objects.create(
-            title='About',
-            page=about_second_dummy_community,
-            community=second_community)
-        self.assertEqual(len(Community.objects.all()), 2)
-        self.assertEqual(len(Page.objects.all()), 3)
-        self.assertEqual(len(CommunityPage.objects.all()), 3)
-        self.assertEqual(about_page_for_second_dummy_community.page,
-                         about_second_dummy_community)
-        self.assertEqual(about_page_for_second_dummy_community.community,
-                         second_community)
-        second_dummy_community_about = Page.objects.get(
-            communitypage=about_page_for_second_dummy_community)
-        self.assertEqual(about_page_for_second_dummy_community,
-                         second_dummy_community_about.communitypage)
-        second_dummy_community_about = Page.objects.get(
-            communitypage=about_page_for_second_dummy_community)
-        self.assertEqual(about_second_dummy_community,
-                         second_dummy_community_about)
+        self.assertEqual(about_dummy_community.community, community)
+        about_dummy_community.delete()
+        self.assertEqual(len(CommunityPage.objects.all()), 0)
 
     def test_signal_registry(self):
         """Test if the function was registered as a signal receiver"""

--- a/systers_portal/dashboard/views.py
+++ b/systers_portal/dashboard/views.py
@@ -1,0 +1,11 @@
+from django.shortcuts import get_object_or_404
+from django.shortcuts import render_to_response
+from django.template import RequestContext
+
+from dashboard.models import CommunityPage
+
+
+def edit_page(request, community_slug, page_slug):
+    page = get_object_or_404(CommunityPage, slug=page_slug)
+    return render_to_response('page_template.html', {'page': page},
+                              context_instance=RequestContext(request))

--- a/systers_portal/systers_portal/settings/base.py
+++ b/systers_portal/systers_portal/settings/base.py
@@ -84,6 +84,7 @@ AUTHENTICATION_BACKENDS = (
     'allauth.account.auth_backends.AuthenticationBackend',
 )
 
+
 ROOT_URLCONF = 'systers_portal.urls'
 
 WSGI_APPLICATION = 'systers_portal.wsgi.application'
@@ -97,6 +98,10 @@ CMS_TEMPLATES = (
 
 LANGUAGES = [
     ('en-us', 'English'),
+]
+CMS_TOOLBARS = [
+    'cms.cms_toolbar.PlaceholderToolbar',
+    'cms.cms_toolbar.PageToolbar',
 ]
 
 

--- a/systers_portal/systers_portal/urls.py
+++ b/systers_portal/systers_portal/urls.py
@@ -10,5 +10,7 @@ urlpatterns = patterns(
     '',
     url(r'^admin/', include(admin.site.urls)),
     url(r'^accounts/', include('allauth.urls')),
+    url(r'^(?P<community_slug>[a-zA-Z0-9_-]+)/(?P<page_slug>[a-zA-Z0-9_-]+)'
+        r'/edit/$', 'dashboard.views.edit_page', name='edit_page'),
     url(r'^', include('cms.urls')),
 )

--- a/systers_portal/templates/page_template.html
+++ b/systers_portal/templates/page_template.html
@@ -1,6 +1,5 @@
 {% extends "cms_base.html" %}
 {% load cms_tags %}
-
 {% block base_content %}
-  {% placeholder page_content %}
+  {% render_placeholder page.editable_content language 'en-us' %}
 {% endblock %}


### PR DESCRIPTION
Placeholders are special model fields that django CMS uses to render user-editable content (plugins) in templates. That is, it’s the place where a user can add text, video or any other plugin to a webpage, using the same frontend editing as the CMS pages. 
This seems to be more simpler instead of using cms page model since we just want front end editing.
Django-cms allows front end editing  on placeholder fields or cms-page only for staff members having required permissions. In any case either we use Placeholder fields or cms page model , only staff members will be able to edit content.

Community page model now has 3 new fields : placeholder field (editable content) , editors, creator.
Any user with staff status, having add,delete,change permissions on plugins and in editors list for the page will be able to edit the page through front end editing.
