### PR TITLE
Community profile form

### DIFF
--- a/systers_portal/dashboard/forms.py
+++ b/systers_portal/dashboard/forms.py
@@ -1,0 +1,11 @@
+from django.forms import ModelForm
+
+from dashboard.models import Community
+
+
+class CommunityForm(ModelForm):
+    """Community profile form excluding the members ManyToManyField
+    """
+    class Meta:
+        model = Community
+        exclude = ['members']


### PR DESCRIPTION
Community profile form excludes members field. The membership of users is going to be implemented separately as "Manage users" page.

The following PR includes `forms.py`, which is also present in #26. 
