### PR TITLE
Add editorconfig file #111

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# http://editorconfig.org
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.{html,json}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.{scss,js}]
+indent_style = tab
+indent_size = tab
+
+
+# Customizations for third party libraries
+
+[static/scss/{font-awesome/*.scss,_font-awesome.scss}]
+indent_style = space
+indent_size = 2
+
+[static/js/lib/**]
+trim_trailing_whitespace = ignore
+insert_final_newline = ignore
+indent_style = ignore

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,16 +13,12 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = false
 
-[*.{scss,js}]
-indent_style = tab
-indent_size = tab
+[*.{css,js}]
+indent_style = space 
+indent_size = 2
 
 
 # Customizations for third party libraries
-
-[static/scss/{font-awesome/*.scss,_font-awesome.scss}]
-indent_style = space
-indent_size = 2
 
 [static/js/lib/**]
 trim_trailing_whitespace = ignore


### PR DESCRIPTION
Closes #111 

Add editorconfig file to help developers on different editors and IDEs maintain a consistent coding style. This file  uses the core Django configuration.