### PR TITLE
edit profile and leave options not on other user's profiles

### DIFF
--- a/systers_portal/systers_portal/settings/dev.py
+++ b/systers_portal/systers_portal/settings/dev.py
@@ -7,9 +7,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'systersdb',
-        'USER': 'navya',
-        
-	
+        'USER': '',
     }
 }
 

--- a/systers_portal/systers_portal/settings/dev.py~
+++ b/systers_portal/systers_portal/settings/dev.py~
@@ -7,9 +7,10 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'systersdb',
-        'USER': 'navya',
-        
-	
+	'USER': 'navya',
+        'PASSWORD': 'navyakhare',
+        'HOST': 'localhost',
+        'PORT': '5432',
     }
 }
 

--- a/systers_portal/templates/meetup/snippets/user-cell.html
+++ b/systers_portal/templates/meetup/snippets/user-cell.html
@@ -3,7 +3,7 @@
 <div class="user-cell-wh-100">
   {% if user.profile_picture.name and user.profile_picture.name != "False" %}
     <a href="{{ user.get_absolute_url }}">
-      <img src="{{ user.profile_picture_thumbnail.url }}" class="img-responsive" alt="{{ user }} profile picture"/>
+      <img src="{{ user.profile_picture_thumbnail.png }}" class="img-responsive" alt="{{ user }} profile picture"/>
     </a>
   {% else %}
     <a href="{{ user.get_absolute_url }}">      

--- a/systers_portal/templates/users/edit_profile.html
+++ b/systers_portal/templates/users/edit_profile.html
@@ -3,8 +3,6 @@
 {% block title %}
   {% if user == systersuser.user %}
     - Edit my profile
-  {% else %}
-    - Edit profile of {{ systersuser }}
   {% endif %}
 {% endblock %}
 

--- a/systers_portal/templates/users/snippets/membership.html
+++ b/systers_portal/templates/users/snippets/membership.html
@@ -10,7 +10,7 @@
               <a href="{% url "view_community_landing" community.slug %}" class="table-anchor">{{ community }}</a>
             </td>
             <td>
-              {% if user == systersuser.user or user.is_superuser %}
+              {% if user == systersuser.user %}
                 {% if systersuser == community.admin %}
                   <a href="{% url 'transfer_ownership' community.slug %}" role="button"
                      class="btn btn-primary btn-xs btn-warning pull-right">Transfer ownership</a>

--- a/systers_portal/templates/users/snippets/profile.html
+++ b/systers_portal/templates/users/snippets/profile.html
@@ -26,7 +26,7 @@
         {% endif %}
       {% endwith %}
     {% endfor %}
-    {% if user == systersuser.user or user.is_superuser %}
+    {% if user == systersuser.user %}
       <div class="pull-right">
         <a href="{% url 'user_profile' systersuser.user.username %}"
            role="button" class="btn btn-primary">Edit profile</a>


### PR DESCRIPTION
When viewing other user's profiles, edit profile and leave options are appearing. ![screenshot from 2017-01-11 13 23 04](https://cloud.githubusercontent.com/assets/15890560/22076158/e620bf3a-ddd4-11e6-8274-0b527292ddfa.png)
Fixed the above issue. ![screenshot from 2017-01-11 13 31 59](https://cloud.githubusercontent.com/assets/15890560/22076155/e50ffb4c-ddd4-11e6-9835-dbdcc896c69a.png)
![screenshot from 2017-01-11 13 32 23](https://cloud.githubusercontent.com/assets/15890560/22076156/e552a23a-ddd4-11e6-8ee9-4c86588cb164.png)
