### PR TITLE
Fix #222 Redirect screenflow after sending/cancelling community join request

### DIFF
--- a/systers_portal/membership/tests/test_views.py
+++ b/systers_portal/membership/tests/test_views.py
@@ -185,19 +185,21 @@ class RequestJoinCommunityViewTestCase(TestCase):
 
     def test_request_join_community_view(self):
         """Test GET request to join a community"""
+        current_url = reverse("view_community_news_list", kwargs={'slug': 'foo'})
         url = reverse("request_join_community", kwargs={'slug': 'foo'})
-        response = self.client.get(url)
+        response = self.client.get(url, {'current_url': current_url})
         self.assertEqual(response.status_code, 403)
 
         user = User.objects.create_user(username='bar', password='foobar')
         systers_user = SystersUser.objects.get(user=user)
         self.client.login(username="bar", password="foobar")
+        nonexistentnews_url = reverse("view_community_news_list", kwargs={'slug': 'new'})
         nonexistent_url = reverse("request_join_community",
                                   kwargs={'slug': 'new'})
-        response = self.client.get(nonexistent_url)
+        response = self.client.get(nonexistent_url, {'current_url': nonexistentnews_url})
         self.assertEqual(response.status_code, 404)
 
-        response = self.client.get(url, follow=True)
+        response = self.client.get(url, {'current_url': current_url}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(JoinRequest.objects.get())
         self.assertFalse(JoinRequest.objects.get().is_approved)
@@ -209,7 +211,7 @@ class RequestJoinCommunityViewTestCase(TestCase):
                 'In a short while someone will review your request.'
                 in message.message)
 
-        response = self.client.get(url, follow=True)
+        response = self.client.get(url, {'current_url': current_url}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(JoinRequest.objects.all().count(), 1)
         self.assertFalse(JoinRequest.objects.get().is_approved)
@@ -223,7 +225,7 @@ class RequestJoinCommunityViewTestCase(TestCase):
         join_request = JoinRequest.objects.get()
         join_request.approve()
         self.community.add_member(systers_user)
-        response = self.client.get(url, follow=True)
+        response = self.client.get(url, {'current_url': current_url}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(JoinRequest.objects.all().count(), 1)
         self.assertTrue(JoinRequest.objects.get().is_approved)
@@ -245,19 +247,21 @@ class CancelCommunityJoinRequestView(TestCase):
 
     def test_cancel_community_join_request(self):
         """Test GET request to cancel a join request to a community"""
+        current_url = reverse("view_community_news_list", kwargs={'slug': 'foo'})
         url = reverse("cancel_community_join_request", kwargs={'slug': 'foo'})
-        response = self.client.get(url)
+        response = self.client.get(url, {'current_url': current_url})
         self.assertEqual(response.status_code, 403)
 
         user = User.objects.create_user(username='bar', password='foobar')
         systers_user = SystersUser.objects.get(user=user)
         self.client.login(username="bar", password="foobar")
+        nonexistentnews_url = reverse("view_community_news_list", kwargs={'slug': 'new'})
         nonexistent_url = reverse("request_join_community",
                                   kwargs={'slug': 'new'})
-        response = self.client.get(nonexistent_url)
+        response = self.client.get(nonexistent_url, {'current_url': nonexistentnews_url})
         self.assertEqual(response.status_code, 404)
 
-        response = self.client.get(url, follow=True)
+        response = self.client.get(url, {'current_url': current_url}, follow=True)
         self.assertEqual(response.status_code, 200)
         for message in response.context['messages']:
             self.assertEqual(message.tags, "warning")
@@ -267,7 +271,7 @@ class CancelCommunityJoinRequestView(TestCase):
 
         JoinRequest.objects.create(user=systers_user, community=self.community)
         self.assertEqual(JoinRequest.objects.all().count(), 1)
-        response = self.client.get(url, follow=True)
+        response = self.client.get(url, {'current_url': current_url}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(JoinRequest.objects.all().count(), 0)
         for message in response.context['messages']:
@@ -278,7 +282,7 @@ class CancelCommunityJoinRequestView(TestCase):
 
         self.community.add_member(systers_user)
         self.community.save()
-        response = self.client.get(url, follow=True)
+        response = self.client.get(url, {'current_url': current_url}, follow=True)
         self.assertEqual(response.status_code, 200)
         for message in response.context['messages']:
             self.assertEqual(message.tags, "warning")

--- a/systers_portal/membership/views.py
+++ b/systers_portal/membership/views.py
@@ -140,8 +140,8 @@ class RequestJoinCommunityView(LoginRequiredMixin, SingleObjectMixin,
     # reach version 1.5
 
     def get_redirect_url(self, *args, **kwargs):
-        """Redirect to user profile page"""
-        return reverse("user", kwargs={'username': self.request.user.username})
+        """Redirect to the page the user was previously on"""
+        return self.request.GET.get('current_url')
 
     def get(self, request, *args, **kwargs):
         """Attempt to create a join request and add a message about the result.
@@ -176,8 +176,8 @@ class CancelCommunityJoinRequestView(LoginRequiredMixin, SingleObjectMixin,
     # reach version 1.5
 
     def get_redirect_url(self, *args, **kwargs):
-        """Redirect to user profile page"""
-        return reverse("user", kwargs={'username': self.request.user.username})
+        """Redirect to the page the user was previously on"""
+        return self.request.GET.get('current_url')
 
     def get(self, request, *args, **kwargs):
         """Attempt to cancel user join request towards a community"""

--- a/systers_portal/templates/community/snippets/join_button.html
+++ b/systers_portal/templates/community/snippets/join_button.html
@@ -12,16 +12,16 @@
         {% if join_request %}
           {# user requested to join the community and the request is not yet approved #}
           {% if not join_request.is_approved %}
-            <a href="{% url "cancel_community_join_request" community.slug %}"
+            <a href="{% url "cancel_community_join_request" community.slug %}?current_url={{request.path}}"
                role="button" class="btn btn-warning btn-block">Cancel request</a>
           {# user was a community member #}
           {% elif not is_member and join_request.is_approved %}
-            <a href="{% url "request_join_community" community.slug %}"
+            <a href="{% url "request_join_community" community.slug %}?current_url={{request.path}}"
                role="button" class="btn btn-success btn-block">Join Community</a>
           {% endif %}
         {% else %}
           {# user is not a member of the community #}
-          <a href="{% url "request_join_community" community.slug %}"
+          <a href="{% url "request_join_community" community.slug %}?current_url={{request.path}}"
              role="button" class="btn btn-success btn-block">Join Community</a>
         {% endif %}
       {% endif %}


### PR DESCRIPTION
This is in reference to the issue #222 . Kindly review.