### PR TITLE
Country dropdown values in local dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Setup for developers
   shell variable every time you activate the virtualenv, edit `venv/bin/activate`
   and add to the bottom the export statement.
 1. Run `python systers_portal/manage.py migrate`.
+1. Run `python manage.py cities_light` for downloading and importing data for django-cities-light.
 1. Run `python systers_portal/manage.py createsuperuser` to create a superuser for the admin panel.
   Fill in the details asked.
 1. Run `python systers_portal/manage.py runserver` to start the development server. When in testing
@@ -76,6 +77,7 @@ production at the moment. It may be configured to do so in the future.
 1. **This step will require the Django SECRET_KEY.**
    Run `docker run -e SECRET_KEY=foobarbaz portal_web`.
 1. Run `docker-compose run web python systers_portal/manage.py migrate`.
+1. Run `docker-compose run web python manage.py cities_light` for downloading and importing data for django-cities-light.
 1. *Optional:*
    Run `docker-compose run web python systers_portal/manage.py createsuperuser`
    if you wish to create a superuser to access the admin panel.


### PR DESCRIPTION
Closes #211 
The country dropdown values were not showing up because of the absence of instructions for importing and downloading cities_light data in local dev instructions in README.md 
![imgonline-com-ua-resize-yu9xe9kbknu](https://user-images.githubusercontent.com/20443665/31423793-54fc9f30-ae74-11e7-909c-ba148e47caaf.jpg)
