### PR TITLE
Fix #206 Embed new community proposal form on new page /propose/newcommunity/

### DIFF
--- a/systers_portal/common/views.py
+++ b/systers_portal/common/views.py
@@ -11,3 +11,7 @@ class ContactView(TemplateView):
 
 class AboutUsView(TemplateView):
     template_name = "common/about_us.html"
+
+
+class NewCommunityProposalView(TemplateView):
+    template_name = "common/new_community_proposal.html"

--- a/systers_portal/static/css/style.css
+++ b/systers_portal/static/css/style.css
@@ -157,6 +157,18 @@ body > .container {
   margin: 0 5px;
 }
 
+/* Common: new community proposal form
+---------------------------------------------------*/
+#google-embed-form{
+  overflow: auto;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  border: 0;
+}
+
 /* social icons contact page
 ---------------------------------------------------*/
 .facebook_icon {

--- a/systers_portal/systers_portal/urls.py
+++ b/systers_portal/systers_portal/urls.py
@@ -8,6 +8,7 @@ from ckeditor import views
 from common.views import IndexView
 from common.views import ContactView
 from common.views import AboutUsView
+from common.views import NewCommunityProposalView
 
 try:
     admin.autodiscover()
@@ -30,6 +31,8 @@ urlpatterns = patterns(
         name='ckeditor_browse'),
     url(r'^contact/$', ContactView.as_view(), name='contact'),
     url(r'^about-us/$', AboutUsView.as_view(), name='about-us'),
+    url(r'^propose/newcommunity/$', NewCommunityProposalView.as_view(),
+        name='new-community-proposal'),
 )
 
 if settings.DEBUG:

--- a/systers_portal/templates/base.html
+++ b/systers_portal/templates/base.html
@@ -46,8 +46,8 @@
               </li>
             {% endfor %}
               <li role="presentation">
-                <a role="menuitem" tabindex="-1" target="_blank"
-                   href="https://docs.google.com/forms/d/1m-SlwamAD6tycq9-GDBPbWsr_m6Ih-eGeqEhb7sn6LQ/viewform">
+                <a role="menuitem" tabindex="-1"
+                   href="{% url 'new-community-proposal' %}">
                   New Community Proposal</a>
               </li>
           </ul>

--- a/systers_portal/templates/common/new_community_proposal.html
+++ b/systers_portal/templates/common/new_community_proposal.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+{% block content %}
+<iframe id="google-embed-form" src="https://docs.google.com/forms/d/1m-SlwamAD6tycq9-GDBPbWsr_m6Ih-eGeqEhb7sn6LQ/viewform?embedded=true" width="100%" height="100%" frameborder="0"></iframe>
+{% endblock %}


### PR DESCRIPTION
Closes #206 .
The screenshot of the new page is attached below.
![screenshot from 2017-10-12 00-53-18](https://user-images.githubusercontent.com/20443665/31461959-a2a19852-aee8-11e7-9b07-c252c5da5230.png)
