### PR TITLE
Fixes #193 (second todo) and #250 Restricts maximum number of characters that can be entered

### DIFF
--- a/systers_portal/users/forms.py
+++ b/systers_portal/users/forms.py
@@ -7,6 +7,13 @@ from users.models import SystersUser
 
 class UserForm(forms.ModelForm):
     """User form combined with SystersUserForm"""
+    first_name = forms.CharField(max_length=20,
+                                 help_text='Maximum characters allowed: 20',
+                                 required=False)
+    last_name = forms.CharField(max_length=20,
+                                help_text='Maximum characters allowed: 20',
+                                required=False)
+
     class Meta:
         model = User
         fields = ('first_name', 'last_name')


### PR DESCRIPTION
This is in reference to [#193](https://github.com/systers/portal/issues/193)(second todo) and [#250](https://github.com/systers/portal/issues/250). 

It restricts the user from entering more than 20 characters in the **First Name** and **Last Name** label and also displays the maximum number of characters that a user can enter (near the label). Hence, fulfilling the demands of both the issues.

