### PR TITLE
Always provide all password requirements to user

### DIFF
--- a/systers_portal/users/adapter.py
+++ b/systers_portal/users/adapter.py
@@ -19,16 +19,12 @@ class SystersUserAccountAdapter(DefaultAccountAdapter):
         digit = re.match(z, password)
         special_char = set(y).intersection(password)
         uppercase = re.match(x, password)
-        if len(password) >= 6:
-            if digit and uppercase and special_char:
-                return password
-
-            else:
-                raise ValidationError(
-                    "Password must have at least, 6 characters, one uppercase letter, "
-                    "one special character and one digit.")
+        if len(password) >= 6 and digit and uppercase and special_char:
+            return password
         else:
-            raise ValidationError("Password must have atleast 6 characters")
+            raise ValidationError(
+                "Password must have at least, 6 characters, one uppercase letter, "
+                "one special character and one digit.")
 
     def get_login_redirect_url(self, request):
         return reverse('user', args=[request.user.username])


### PR DESCRIPTION
Before, if user entered password shorter than 6 chars they still weren't provided with full requirements.

 Link: https://github.com/systers/portal/issues/247
 Fixes: a0671e0b9bb7 ("Show all necessary check for password strength")