### PR TITLE
Save username field on new user creation

### DIFF
--- a/systers_portal/users/adapter.py
+++ b/systers_portal/users/adapter.py
@@ -10,6 +10,7 @@ class SystersUserAccountAdapter(DefaultAccountAdapter):
     def clean_username(self, username, shallow=False):
         if len(username) < 3:
             raise ValidationError("Username must be atleast 3 characters long")
+        return username
 
     def clean_password(self, password):
         # Password should have at least one uppercase letter, one digit and one special character


### PR DESCRIPTION
clean_username() in SystersUserAccountAdapter class did not return any value for valid username.
As a result, proper usernames were ignored and substituted by first part of email address.

I think, it would be nice to have selenium autotests for user signup. 