### PR TITLE
Authenticating users while signing up

### DIFF
--- a/systers_portal/systers_portal/settings/base.py
+++ b/systers_portal/systers_portal/settings/base.py
@@ -127,6 +127,7 @@ MEDIA_URL = "/media/"
 # https://django-allauth.readthedocs.org/en/latest/#configuration
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_ADAPTER = 'users.adapter.SystersUserAccountAdapter'
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 
 # Ckeditor configuration
 CKEDITOR_UPLOAD_PATH = "uploads/"

--- a/systers_portal/systers_portal/settings/dev.py
+++ b/systers_portal/systers_portal/settings/dev.py
@@ -18,4 +18,6 @@ INTERNAL_IPS = ('127.0.0.1',)
 
 # Instead of sending out real email, during development the emails will be sent
 # to stdout, where from they can be inspected.
+EMAIL_HOST = 'localhost'
+EMAIL_PORT = 25
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
Solves #181

Used django-allauth's configuration settings to authenticate users while signing up.