### PR TITLE
Add hint to models URLfields

### DIFF
--- a/systers_portal/community/models.py
+++ b/systers_portal/community/models.py
@@ -24,13 +24,17 @@ class Community(models.Model):
     parent_community = models.ForeignKey('self', blank=True, null=True,
                                          verbose_name="Parent community")
     website = models.URLField(max_length=255, blank=True,
-                              verbose_name="Website")
+                              verbose_name="Website",
+                              help_text="Enter URL starting with http(s)://")
     facebook = models.URLField(max_length=255, blank=True,
-                               verbose_name="Facebook")
+                               verbose_name="Facebook",
+                               help_text="Enter URL starting with http(s)://")
     googleplus = models.URLField(max_length=255, blank=True,
-                                 verbose_name="Google+")
+                                 verbose_name="Google+",
+                                 help_text="Enter URL starting with http(s)://")
     twitter = models.URLField(max_length=255, blank=True,
-                              verbose_name="Twitter")
+                              verbose_name="Twitter",
+                              help_text="Enter URL starting with http(s)://")
     __original_name = None
     __original_admin = None
 

--- a/systers_portal/users/models.py
+++ b/systers_portal/users/models.py
@@ -16,9 +16,11 @@ class SystersUser(models.Model):
     """Profile model to store additional information about a user"""
     user = models.OneToOneField(User)
     country = models.ForeignKey(Country, blank=True, null=True, verbose_name="Country")
-    blog_url = models.URLField(max_length=255, blank=True, verbose_name="Blog")
+    blog_url = models.URLField(max_length=255, blank=True, verbose_name="Blog",
+                               help_text="Enter URL starting with http(s)://")
     homepage_url = models.URLField(max_length=255, blank=True,
-                                   verbose_name="Homepage")
+                                   verbose_name="Homepage",
+                                   help_text="Enter URL starting with http(s)://")
     profile_picture = models.ImageField(upload_to='users/pictures/',
                                         blank=True,
                                         null=True,


### PR DESCRIPTION
Hints to enter valid URL are added to user and community models' URLfields.
Hints added to models rather than forms are visible on any forms
including admin ones. 
But if you think it's better to do through forms I'll make another commit.

Link: https://github.com/systers/portal/issues/193