### PR TITLE
Redirecting Map Marker to a meetup location

### DIFF
--- a/systers_portal/templates/meetup/snippets/meetup_locations_map.html
+++ b/systers_portal/templates/meetup/snippets/meetup_locations_map.html
@@ -16,7 +16,8 @@
       {% for location in object_list %}
           var point = new google.maps.LatLng({{location.location.latitude}},{{location.location.longitude}});
           var marker = new google.maps.Marker({position: point, map: map, title: '{{ location.name }}',});
-          marker['infowindow']  = new google.maps.InfoWindow({content: "<h4>{{location.name}}</h4>",});
+          marker['infowindow'] = new google.maps.InfoWindow({content: 
+            "<a href='{% url "about_meetup_location" location.slug %}'>{{location}}</a>", });
           google.maps.event.addListener(marker, 'click', function() {this['infowindow'].open(map, this);});
       {% endfor %}    
   }


### PR DESCRIPTION
Partially solves #265 
In this PR, I modified the map markers such that they redirect to meetup locations.
![image](https://user-images.githubusercontent.com/13400691/33591259-8c839da8-d9aa-11e7-8f2b-80995e316220.png)

Todos:

-  Implement text search for meetup locations.This I am planning to do after migrating Portal (https://docs.djangoproject.com/en/1.11/ref/contrib/postgres/search/)




