### PR TITLE
Systers Twitter feed on Meetup location list page

### DIFF
--- a/systers_portal/templates/meetup/list_location.html
+++ b/systers_portal/templates/meetup/list_location.html
@@ -9,6 +9,13 @@
   <div class="row">
     <div id="map-canvas" class="map-container mt20"></div>
   </div>
-  {% include "meetup/snippets/meetup_locations_grid.html" %}
+  <div class="row">
+    <div class="col-sm-8">
+        {% include "meetup/snippets/meetup_locations_grid.html" %}
+    </div>
+    <div class="col-sm-4 mt20">
+        {% include "meetup/snippets/systers_twitter_feed.html" %}               
+    </div>
+  </div>
   {% include "meetup/snippets/meetup_locations_map.html" %}
 {% endblock %}

--- a/systers_portal/templates/meetup/snippets/systers_twitter_feed.html
+++ b/systers_portal/templates/meetup/snippets/systers_twitter_feed.html
@@ -1,0 +1,4 @@
+<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+<a class="twitter-timeline" data-width="500" data-height="600" data-theme="light" data-link-color="#26A9E0" href="https://twitter.com/systers_org">
+   Tweets by systers
+</a>


### PR DESCRIPTION
#269 
Twitter feed on Meetup Location list page is added. 
![image](https://user-images.githubusercontent.com/13400691/33772106-7c853464-dc59-11e7-9602-209d6244ab0d.png)

Credits: https://github.com/OpenSourceHelpCommunity/OpenSourceHelpCommunity.github.io/blob/predev/oshc/main/templates/index.html