### PR TITLE
Upcoming meetups to Meetuplocation list page

### DIFF
--- a/systers_portal/meetup/tests/test_views.py
+++ b/systers_portal/meetup/tests/test_views.py
@@ -45,25 +45,38 @@ class MeetupLocationAboutViewTestCase(MeetupLocationViewBaseTestCase, TestCase):
 
 class MeetupLocationListViewTestCase(MeetupLocationViewBaseTestCase, TestCase):
     def test_view_meetup_location_list_view(self):
-        """Test Meetup Location list view for correct http response and
-        all meetup locations in a list"""
+        """Test Meetup Location list view for correct http response,
+        all meetup locations in a list and all upcoming meetups"""
         url = reverse('list_meetup_location')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "meetup/list_location.html")
         self.assertContains(response, "Foo Systers")
+        self.assertContains(response, "Foo Bar Baz")
         self.assertContains(response, "google.maps.Map")
+        self.assertEqual(len(response.context['object_list']), 1)
+        self.assertEqual(len(response.context['meetup_list']), 1)
 
         self.meetup_location2 = MeetupLocation.objects.create(
             name="Bar Systers", slug="bar", location=self.location,
             description="It's a test meetup location")
+        self.meetup2 = Meetup.objects.create(title='Bar Baz', slug='bazbar',
+                                             date=(timezone.now() + timezone.timedelta(2)).date(),
+                                             time=timezone.now().time(),
+                                             description='This is new test Meetup',
+                                             meetup_location=self.meetup_location2,
+                                             created_by=self.systers_user,
+                                             last_updated=timezone.now())
         url = reverse('list_meetup_location')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "meetup/list_location.html")
         self.assertContains(response, "Foo Systers")
         self.assertContains(response, "Bar Systers")
+        self.assertContains(response, "Foo Bar Baz")
+        self.assertContains(response, "Bar Baz")
         self.assertEqual(len(response.context['object_list']), 2)
+        self.assertEqual(len(response.context['meetup_list']), 2)
         self.assertContains(response, "google.maps.Map")
 
 

--- a/systers_portal/meetup/views.py
+++ b/systers_portal/meetup/views.py
@@ -31,6 +31,12 @@ class MeetupLocationList(ListView):
     model = MeetupLocation
     paginate_by = 20
 
+    def get_context_data(self, **kwargs):
+        context = super(MeetupLocationList, self).get_context_data(**kwargs)
+        context['meetup_list'] = Meetup.objects.filter(
+            date__gte=datetime.date.today()).order_by('date', 'time')
+        return context
+
 
 class MeetupView(MeetupLocationMixin, DetailView):
     template_name = "meetup/meetup.html"

--- a/systers_portal/static/css/style.css
+++ b/systers_portal/static/css/style.css
@@ -354,6 +354,19 @@ table.decoration-none  tr a {
   margin-right: 15px;
 }
 
+.text-bottom{
+    padding: 10px;
+    border-bottom: 1px solid #eee;
+}
+
+.upcomingMeetupslist{
+  height: 400px;
+  overflow-y: scroll;
+  line-height: 1em;
+  word-wrap: break-word;
+  margin-bottom: 40px;
+}
+
 /* Meetup Location Members user-cell space
 -------------------------------------------------- */
 .user-cell-wh-100 {

--- a/systers_portal/templates/meetup/list_location.html
+++ b/systers_portal/templates/meetup/list_location.html
@@ -13,8 +13,9 @@
     <div class="col-sm-8">
         {% include "meetup/snippets/meetup_locations_grid.html" %}
     </div>
-    <div class="col-sm-4 mt20">
-        {% include "meetup/snippets/systers_twitter_feed.html" %}               
+    <div class="col-sm-4">
+        {% include "meetup/snippets/upcoming_meetups_list.html" %}
+        {% include "meetup/snippets/systers_twitter_feed.html" %}
     </div>
   </div>
   {% include "meetup/snippets/meetup_locations_map.html" %}

--- a/systers_portal/templates/meetup/snippets/upcoming_meetups_list.html
+++ b/systers_portal/templates/meetup/snippets/upcoming_meetups_list.html
@@ -1,0 +1,14 @@
+{% block content %}
+<h3 class="text-bottom"> Upcoming Meetups </h3> 
+	<div class="upcomingMeetupslist">	
+    	{% for meetup in meetup_list %}
+    	<div class="text-bottom ml15">
+      			{{meetup.meetup_location }}
+      			<a href="{% url "view_meetup" meetup.meetup_location.slug meetup.slug %}">
+      				<div>{{ meetup }}</div> 
+      			</a>
+      			{{ meetup.date }}
+      	</div>
+      	{% endfor %}
+ 	</div>
+{% endblock %}


### PR DESCRIPTION
#264 
This PR adds upcoming meetups list to the meetup location list page.
To test this, add a few upcoming meetups from the admin panel, or add it normally.
![image](https://user-images.githubusercontent.com/13400691/33898807-750f4268-df8f-11e7-8c88-231c887467ba.png)

EDIT:
![image](https://user-images.githubusercontent.com/13400691/34077840-9ded4ba6-e333-11e7-9528-ee0ae4e7b89d.png)

