### PR TITLE
Migrate psycopg for travis to work 

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -8,5 +8,5 @@ django-crispy-forms==1.4.0
 django-guardian==1.2.5
 django-imagekit==3.2.6
 djangocms-admin-style==0.2.5
-psycopg2==2.6
+psycopg2==2.7.3.2
 python3-openid>=3.0.1


### PR DESCRIPTION
In reference to issue #201  
Reason for only upgrading psycopg in this PR,
Like in [PR1](https://travis-ci.org/systers/portal/builds/317569145?utm_source=github_status&utm_medium=notification) and [PR2](https://travis-ci.org/systers/portal/builds/317064729?utm_source=github_status&utm_medium=notification). Travis is failing with psycopg version 2.6. 
Related issues:
https://github.com/psycopg/psycopg2/issues/594
https://github.com/travis-ci/travis-ci/issues/8897