### PR TITLE
JoinMeetupLocation Button made visible only to non-members of the meetup.

### DIFF
--- a/systers_portal/templates/meetup/snippets/join_button.html
+++ b/systers_portal/templates/meetup/snippets/join_button.html
@@ -1,5 +1,5 @@
 {% if user.is_authenticated and user.is_active %}
-{% if user in meetup_location.members.all or user in meetup_location.organizers.all %}
+{% if user not in meetup_location.members.all or user not in meetup_location.organizers.all %}
   <div class="sidebar-module mb40">
     <a class="btn btn-success btn-block" href="{% url "join_meetup_location" meetup_location.slug user.username %}" role="button">Join Meetup Location</a>
   </div>

--- a/systers_portal/templates/meetup/snippets/join_button.html
+++ b/systers_portal/templates/meetup/snippets/join_button.html
@@ -1,5 +1,7 @@
 {% if user.is_authenticated and user.is_active %}
+{% if user in meetup_location.members.all or user in meetup_location.organizers.all %}
   <div class="sidebar-module mb40">
     <a class="btn btn-success btn-block" href="{% url "join_meetup_location" meetup_location.slug user.username %}" role="button">Join Meetup Location</a>
   </div>
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
### Description
Currently, a user can request to be a member by clicking "Join Meetup Location" button.
But the users who are members of a meetup location also are also able to view the button, which will prompt the users to join again.
Hence, changes have been made to make the Join Meetup Location button only visible to the users who're not currently members of the meetup location.

Fixes #312

### Type of Change:
- Code
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] My changes generate no new warnings 
