### PR TITLE
Members/Organizers of a Meetup Location should have the flexibility to change the extent of their involvement in that meetup

### DIFF
--- a/systers_portal/templates/meetup/snippets/join_button.html
+++ b/systers_portal/templates/meetup/snippets/join_button.html
@@ -1,7 +1,17 @@
 {% if user.is_authenticated and user.is_active %}
-{% if user not in meetup_location.members.all or user not in meetup_location.organizers.all %}
+{% if user.systersuser in meetup_location.members.all %}
   <div class="sidebar-module mb40">
+    <a href="{% url "remove_member_meetup_location" meetup_location.slug user.username %}" role="button" class="btn btn-danger btn-block">Leave Meetup Location</a>
+  </div>
+  {% elif user.systersuser in meetup_location.organizers.all %}
+  <div class="sidebar-module mb40">
+    <a href="{% url "remove_organizer_meetup_location" meetup_location.slug user.username %}" role="button" class="btn btn-warning btn-block">Leave as Organizer</a>
+    <br>
+    <a href="{% url "remove_member_meetup_location" meetup_location.slug user.username %}" role="button" class="btn btn-danger btn-block">Leave Meetup Location</a>
+  </div>
+  {% else %}
+	<div class="sidebar-module mb40">
     <a class="btn btn-success btn-block" href="{% url "join_meetup_location" meetup_location.slug user.username %}" role="button">Join Meetup Location</a>
   </div>
   {% endif %}
-{% endif %}
+  {% endif %}

--- a/systers_portal/users/models.py
+++ b/systers_portal/users/models.py
@@ -14,7 +14,7 @@ from membership.constants import (NO_PENDING_JOIN_REQUEST, OK, NOT_MEMBER,
 
 class SystersUser(models.Model):
     """Profile model to store additional information about a user"""
-    user = models.OneToOneField(User)
+    user = models.OneToOneField(User, related_name='systersuser')
     country = models.ForeignKey(Country, blank=True, null=True, verbose_name="Country")
     blog_url = models.URLField(max_length=255, blank=True, verbose_name="Blog")
     homepage_url = models.URLField(max_length=255, blank=True,


### PR DESCRIPTION
### Description
A member of a meetup needs to have a Leave Meetup Location Button,
so that she can have the flexibility of leaving the meetup location if necessary.

Similarly the Organisers of a meetup need to have a Leave as Organiser and a Leave Meetup Location Button. The Leave as Organizer would only remove the Organizer status of the user and he would continue to be a member of the meetup.

Fixes #317 

### Type of Change:
- Code
- User Interface
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
