### PR TITLE
Registering signals when app loads

### DIFF
--- a/systers_portal/community/__init__.py
+++ b/systers_portal/community/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'community.apps.CommunityConfig'

--- a/systers_portal/community/apps.py
+++ b/systers_portal/community/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class CommunityConfig(AppConfig):
+    name = 'community'
+
+    def ready(self):
+        import community.signals

--- a/systers_portal/community/apps.py
+++ b/systers_portal/community/apps.py
@@ -6,3 +6,4 @@ class CommunityConfig(AppConfig):
 
     def ready(self):
         import community.signals
+        assert community.signals

--- a/systers_portal/community/tests/test_apps.py
+++ b/systers_portal/community/tests/test_apps.py
@@ -1,0 +1,9 @@
+from django.apps import apps
+from django.test import TestCase
+from community.apps import CommunityConfig
+
+
+class CommunityConfigTest(TestCase):
+    def test_apps(self):
+        self.assertEqual(CommunityConfig.name, 'community')
+        self.assertEqual(apps.get_app_config('community').name, 'community')

--- a/systers_portal/meetup/__init__.py
+++ b/systers_portal/meetup/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'meetup.apps.MeetupConfig'

--- a/systers_portal/meetup/apps.py
+++ b/systers_portal/meetup/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class MeetupConfig(AppConfig):
+    name = 'meetup'
+
+    def ready(self):
+        import meetup.signals

--- a/systers_portal/meetup/apps.py
+++ b/systers_portal/meetup/apps.py
@@ -6,3 +6,4 @@ class MeetupConfig(AppConfig):
 
     def ready(self):
         import meetup.signals
+        assert meetup.signals

--- a/systers_portal/meetup/tests/test_apps.py
+++ b/systers_portal/meetup/tests/test_apps.py
@@ -1,0 +1,9 @@
+from django.apps import apps
+from django.test import TestCase
+from meetup.apps import MeetupConfig
+
+
+class MeetupConfigTest(TestCase):
+    def test_apps(self):
+        self.assertEqual(MeetupConfig.name, 'meetup')
+        self.assertEqual(apps.get_app_config('meetup').name, 'meetup')


### PR DESCRIPTION
### Description
After the migration, auth groups weren't created, because of this change https://github.com/systers/portal/commit/383f3f31ab3301c4053a499d08b467d7879994b9#diff-8782812c572c66e11f9249755f59f890 
signals weren't working.

Fixes #322 

### Type of Change:
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Auth groups are created after the change.

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged 
