### PR TITLE
add cancel button for non-approved join request

### DIFF
--- a/systers_portal/meetup/urls.py
+++ b/systers_portal/meetup/urls.py
@@ -18,7 +18,8 @@ from meetup.views import (MeetupLocationAboutView, MeetupLocationList, MeetupVie
                           NewMeetupLocationRequestsListView, ViewMeetupLocationRequestView,
                           RejectMeetupLocationRequestView, ApproveRequestMeetupLocationView,
                           RequestMeetupView, NewMeetupRequestsListView, ViewMeetupRequestView,
-                          ApproveRequestMeetupView, RejectMeetupRequestView)
+                          ApproveRequestMeetupView, RejectMeetupRequestView,
+                          CancelMeetupLocationJoinRequestView)
 
 
 urlpatterns = [
@@ -69,6 +70,9 @@ urlpatterns = [
         name='make_organizer_meetup_location'),
     url(r'^(?P<slug>[\w-]+)/join/(?P<username>[\w.@+-]+)/$', JoinMeetupLocationView.as_view(),
         name='join_meetup_location'),
+    url(r'^(?P<slug>[\w-]+)/cancel/(?P<username>[\w.@+-]+)/$',
+        CancelMeetupLocationJoinRequestView.as_view(),
+        name='cancel_meetup_location_join_request'),
     url(r'^(?P<slug>[\w-]+)/join_requests/$', MeetupLocationJoinRequestsView.as_view(),
         name='join_requests_meetup_location'),
     url(r'^(?P<slug>[\w-]+)/join_requests/approve/(?P<username>[\w.@+-]+)/$',

--- a/systers_portal/templates/meetup/snippets/join_button.html
+++ b/systers_portal/templates/meetup/snippets/join_button.html
@@ -1,7 +1,13 @@
 {% if user.is_authenticated and user.is_active %}
-{% if user not in meetup_location.members.all or user not in meetup_location.organizers.all %}
-  <div class="sidebar-module mb40">
-    <a class="btn btn-success btn-block" href="{% url "join_meetup_location" meetup_location.slug user.username %}" role="button">Join Meetup Location</a>
-  </div>
+  {% if user.systersuser not in meetup_location.organizers.all %}
+    {% if user.systersuser not in meetup_location.members.all and user.systersuser not in meetup_location.join_requests.all %}
+      <div class="sidebar-module mb40">
+        <a class="btn btn-success btn-block" href="{% url "join_meetup_location" meetup_location.slug user.username %}"
+           role="button">Join Meetup Location</a>
+      </div>
+    {% elif user.systersuser not in meetup_location.members.all and user.systersuser in meetup_location.join_requests.all %}
+      <a href="{% url "cancel_meetup_location_join_request" meetup_location.slug user.username %}?current_url={{ request.path }}"
+        role="button" class="btn btn-warning btn-block">Cancel request</a>
+    {% endif %}
   {% endif %}
 {% endif %}


### PR DESCRIPTION
### Description
A cancel button is shown when the user has created a join request but the request is not accepted.

Fixes #333

### Type of Change:
- Code
- Quality Assurance
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
This has been tested locally using coverage

### Checklist:

- [x] My PR follows the style guidelines for this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
