### PR TITLE
Enter character is now reflected in comments

### DIFF
--- a/systers_portal/static/css/style.css
+++ b/systers_portal/static/css/style.css
@@ -366,6 +366,17 @@ table.decoration-none  tr a {
   word-wrap: break-word;
   margin-bottom: 40px;
 }
+/* Commentbox CSS
+------------------------------------------------- */
+.comment-box{
+  border: 0px;
+  background-color: white;
+  color: #555555;
+  font-family: Georgia, "Times New Roman", Times, serif;
+  font-size: 1.0em;
+  line-height: 1.0em;
+/*  webkit-text-size-adjust: 100%;*/
+}
 
 /* Meetup Location Members user-cell space
 -------------------------------------------------- */

--- a/systers_portal/templates/meetup/meetup.html
+++ b/systers_portal/templates/meetup/meetup.html
@@ -46,7 +46,7 @@
     <div class="box-container pt25">
       <a href="{{ comment.author.get_absolute_url }}">{{ comment.author}}</a>
       <div class="box-body">
-        <p>{{ comment.body }}</p>
+        <pre class="comment-box">{{ comment.body }}</pre>
       </div>
       {% if user == comment.author.user %}
         <a href="{% url 'edit_meetup_comment' meetup_location.slug meetup.slug comment.id %}">edit</a>

--- a/systers_portal/templates/meetup/support_request.html
+++ b/systers_portal/templates/meetup/support_request.html
@@ -41,7 +41,7 @@
     <div class="box-container pt25">
       <a href="{{ comment.author.get_absolute_url }}">{{ comment.author}}</a>
       <div class="box-body">
-        <p>{{ comment.body }}</p>
+        <pre class="comment-box">{{ comment.body }}</pre>
       </div>
       {% if user == comment.author.user %}
         <a href="{% url 'edit_support_request_comment' meetup_location.slug meetup.slug support_request.pk comment.id %}">edit</a>


### PR DESCRIPTION
### Description
When we hit enter while entering or editing any comments in the discussion area , the new line is now seen in the comments

Fixes #348

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
![screenshot from 2018-03-21 16-36-15](https://user-images.githubusercontent.com/23247839/37706665-55f01cb0-2d26-11e8-884e-d67239bb7060.png)





### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
