### PR TITLE
Integrate commitlint with Github Actions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,19 @@
+# This action uses commitlint to lint commit messages and check for the required guidelines
+# as given by the config file commitlint.config.js
+
+name: Check Commit Messages
+
+on:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2.1.0
+      - run: yarn add @commitlint/{config-conventional,cli}
+      - run: yarn run commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,37 @@
+module.exports = {
+	parserPreset: 'conventional-changelog-conventionalcommits',
+	rules: {
+		'body-leading-blank': [1, 'always'],
+		'body-max-line-length': [2, 'always', 100],
+		'footer-leading-blank': [1, 'always'],
+		'footer-max-line-length': [2, 'always', 100],
+		'header-max-length': [2, 'always', 100],
+		'scope-case': [2, 'always', 'lower-case'],
+		'subject-case': [
+			2,
+			'never',
+			['sentence-case', 'start-case', 'pascal-case', 'upper-case']
+		],
+		'subject-empty': [2, 'never'],
+		'subject-full-stop': [2, 'never', '.'],
+		'type-case': [2, 'always', 'lower-case'],
+		'type-empty': [2, 'never'],
+		'type-enum': [
+			2,
+			'always',
+			[
+				'build',
+				'chore',
+				'ci',
+				'docs',
+				'feat',
+				'fix',
+				'perf',
+				'refactor',
+				'revert',
+				'style',
+				'test'
+			]
+		]
+	}
+};


### PR DESCRIPTION
This PR uses `commitlint` to lint commit messages to follow our [commit guidelines](https://github.com/anitab-org/portal/wiki/Commit-Message-Style-Guide) using Github Actions