### PR TITLE
Chore: Use `--no-cache-dir` flag to `pip` in Dockerfiles, to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN mkdir portal
 RUN cd portal
 WORKDIR /usr/src/portal
 COPY requirements/prod.txt /usr/src/portal/requirements/prod.txt
-RUN pip install -r requirements/prod.txt
+RUN pip install --no-cache-dir -r requirements/prod.txt
 


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>